### PR TITLE
Allow custom attrs to display on in-game screen

### DIFF
--- a/code/init.asm
+++ b/code/init.asm
@@ -242,6 +242,17 @@ Start:
 		rept 8
 			halt
 		endr
+
+if def(CUSTOM_ATTRS)
+		ld hl, CustomChrPackets
+		rept 22
+			call Packet
+			rept 4
+				halt
+			endr
+		endr
+endc
+
 		; border nametable
 		ld hl, BorderTilemap
 		ld de, _VRAM
@@ -493,7 +504,17 @@ GameInit::
 	ld de, _SCRN0
 	ld bc, wGameTilemap.statusbar - wGameTilemap
 	call SafeCpy
-	ret
+if def(CUSTOM_ATTRS)
+; marker to say we're in an in-game state
+	ld hl, .data
+	ld de, wSnesSnakeData
+	ld bc, 8
+	call SafeCpy
+	jr :+
+.data:
+	db $5a, $03, SNAKE_X, SNAKE_Y, SNAKE_X, SNAKE_Y+1, SNAKE_X, SNAKE_Y+2
+endc
+:	ret
 
 SECTION "1bppcpy", ROM0
 SafeCpy1bpp:: ; like "SafeCpy", but modified for 1bpp
@@ -567,6 +588,34 @@ db $01
 ds 5, $00
 db %11000000 | $01
 ds 6, $00
+
+if def(CUSTOM_ATTRS)
+CustomChrPackets:
+db $79, $00, $09, $7e, $0b, $c2, $20, $ad, $84, $02, $18, $69, $30, $15, $85, $03
+db $79, $0b, $09, $7e, $0b, $e2, $20, $a9, $7e, $85, $05, $a7, $03, $c9, $5a, $d0
+db $79, $16, $09, $7e, $0b, $48, $af, $00, $20, $7f, $c9, $01, $f0, $42, $a9, $7e
+db $79, $21, $09, $7e, $0b, $85, $02, $c2, $30, $a9, $3f, $21, $8f, $72, $ad, $7e
+db $79, $2c, $09, $7e, $0b, $a9, $4c, $a9, $85, $00, $a2, $10, $00, $da, $a0, $00
+db $79, $37, $09, $7e, $0b, $00, $a2, $10, $00, $b7, $00, $29, $ff, $e3, $09, $00
+db $79, $42, $09, $7e, $0b, $14, $97, $00, $c8, $c8, $ca, $d0, $f1, $a5, $00, $18
+db $79, $4d, $09, $7e, $0b, $69, $40, $00, $85, $00, $fa, $ca, $d0, $de, $e2, $30
+db $79, $58, $09, $7e, $0b, $a9, $01, $8d, $01, $02, $80, $02, $a9, $00, $8f, $00
+db $79, $63, $09, $7e, $03, $20, $7f, $60, $00, $00, $00, $00, $00, $00, $00, $00 ; 10
+
+db $79, $00, $0a, $7e, $0b, $af, $00, $20, $7f, $d0, $01, $60, $c2, $20, $ad, $84
+db $79, $0b, $0a, $7e, $0b, $02, $18, $69, $31, $15, $85, $00, $e2, $20, $a9, $7e
+db $79, $16, $0a, $7e, $0b, $85, $02, $85, $07, $a9, $00, $85, $04, $85, $08, $a0
+db $79, $21, $0a, $7e, $0b, $00, $b7, $00, $d0, $01, $60, $b7, $00, $d0, $06, $a9
+db $79, $2c, $0a, $7e, $0b, $01, $8d, $01, $02, $60, $10, $1b, $29, $7f, $aa, $c8
+db $79, $37, $0a, $7e, $0b, $a9, $14, $85, $09, $20, $56, $0a, $a7, $05, $29, $ff
+db $79, $42, $0a, $7e, $0b, $e3, $05, $08, $87, $05, $e2, $20, $ca, $d0, $ef, $80
+db $79, $4d, $0a, $7e, $0b, $d9, $aa, $c8, $a9, $04, $85, $09, $80, $e5, $da, $b7
+db $79, $58, $0a, $7e, $0b, $00, $c8, $0a, $85, $03, $b7, $00, $c8, $c2, $20, $29
+db $79, $63, $0a, $7e, $0b, $ff, $00, $0a, $0a, $0a, $0a, $0a, $0a, $18, $65, $03
+db $79, $6e, $0a, $7e, $07, $69, $4c, $a9, $85, $05, $fa, $60, $00, $00, $00, $00 ; 11
+
+db $79, $08, $08, $7e, $0b, $4c, $00, $09, $00, $00, $00, $00, $00, $4c, $00, $0a ; 1
+endc
 
 SECTION "rampackets", WRAM0
 wSPalTitle::	ds 16

--- a/custom_attrs.s
+++ b/custom_attrs.s
@@ -1,0 +1,212 @@
+.memorymap
+	defaultslot 0
+
+	slotsize $10000
+	slot 0 $0000
+.endme
+
+.banksize $10000
+.rombanks 1
+
+.asciitable
+.enda
+
+.base $00
+
+.bank $000 slot 0
+
+.org $808
+	jmp PreHook
+
+.org $810
+	jmp PostHook
+
+.org $900
+
+GB_SNES_DATA_OFFS = $1530
+GB_TILEMAP_BUFFER = $a94c
+IN_SNEK_GAMEPLAY = $7f2000
+wPendingGBScreensBG3Update = $201
+wCurrPtrGBTileDataBuffer = $284
+
+.macro acc16
+	rep #$20
+	.accu 16
+.endm
+
+.macro idx16
+	rep #$10
+	.index 16
+.endm
+
+.macro accidx16
+	rep #$30
+	.accu 16
+	.index 16
+.endm
+
+.macro acc8
+	sep #$20
+	.accu 8
+.endm
+
+.macro idx8
+	sep #$10
+	.index 8
+.endm
+
+.macro accidx8
+	sep #$30
+	.accu 8
+	.index 8
+.endm
+
+.redef TILE_MAP_DEST = $00 ; l
+.redef TILE_DATA_SRC = $03 ; l
+PreHook:
+; get ctrl byte from gb's tile data
+	acc16
+	lda wCurrPtrGBTileDataBuffer
+	clc
+	adc #GB_SNES_DATA_OFFS
+	sta TILE_DATA_SRC
+	acc8
+	lda #$7e
+	sta TILE_DATA_SRC+2
+	lda [TILE_DATA_SRC]
+
+	cmp #$5a
+	bne @unset
+; if flag is 1, keep setting to 1
+	lda IN_SNEK_GAMEPLAY
+	cmp #$01
+	beq @set
+; flag is 0, set tilemap
+	lda #$7e
+	sta TILE_MAP_DEST+2
+	accidx16
+; hide info tile
+	lda #$213f
+	sta $7ead72
+; set 16x16 tilemap
+	lda #GB_TILEMAP_BUFFER
+	sta TILE_MAP_DEST
+	ldx #$10
+	@nextTileRow:
+		phx
+		ldy #$00
+		ldx #$10
+		@nextTileCol:
+			lda [TILE_MAP_DEST], Y
+			and #$e3ff
+			ora #$1400
+			sta [TILE_MAP_DEST], Y
+			iny
+			iny
+			dex
+			bne @nextTileCol
+		lda TILE_MAP_DEST
+		clc
+		adc #$40
+		sta TILE_MAP_DEST
+		plx
+		dex
+		bne @nextTileRow
+	accidx8
+; update BG3, set flag to 1 (init done)
+	lda #$01
+	sta wPendingGBScreensBG3Update
+	bra @set
+@unset:
+	lda #$00
+@set:
+	sta IN_SNEK_GAMEPLAY
+	rts
+
+.orga $a00
+
+.redef TILE_DATA_SRC = $00 ; l
+.redef DOUBLE_SNAKE_X = $03 ; w
+.redef TILE_MAP_DEST = $05 ; l
+.redef ORA_ATTR = $08 ; w
+; palettes in p: vhopppcc cccccccc
+PostHook:
+	lda IN_SNEK_GAMEPLAY
+	bne +
+	rts
++	acc16
+	lda wCurrPtrGBTileDataBuffer
+	clc
+	adc #GB_SNES_DATA_OFFS+1
+	sta TILE_DATA_SRC
+	acc8
+	lda #$7e
+	sta TILE_DATA_SRC+2
+; bank of dest
+	sta TILE_MAP_DEST+2
+; high of snake X
+	lda #$00
+	sta DOUBLE_SNAKE_X+1
+; low of nametable attr
+	sta ORA_ATTR
+	ldy #$00
+; 0 read straight away? dont update BG3
+	lda [TILE_DATA_SRC], Y
+	bne @nextCtrl
+	rts
+@nextCtrl:
+	lda [TILE_DATA_SRC], Y
+	bne +
+	lda #$01
+	sta wPendingGBScreensBG3Update
+	rts
++	bpl @addPart
+; subPart
+	and #$7f
+	tax
+	iny
+	lda #$14
+	sta ORA_ATTR+1
+
+	@nextNode:
+		jsr GetSnakePosAndOffs
+		.accu 16
+		lda [TILE_MAP_DEST]
+		and #$e3ff
+		ora ORA_ATTR
+		sta [TILE_MAP_DEST]
+		acc8
+		dex
+		bne @nextNode
+	bra @nextCtrl
+
+@addPart:
+	tax
+	iny
+	lda #$04
+	sta ORA_ATTR+1
+	bra @nextNode
+
+
+; Sets accu to 16
+GetSnakePosAndOffs:
+	phx
+; put snake X in X
+	lda [TILE_DATA_SRC], Y
+	iny
+	asl
+	sta DOUBLE_SNAKE_X
+; add on snake Y
+	lda [TILE_DATA_SRC], Y
+	iny
+	acc16
+	and #$00ff.w
+.rept 6
+	asl
+.endr
+	clc
+	adc DOUBLE_SNAKE_X
+	adc #GB_TILEMAP_BUFFER
+	sta TILE_MAP_DEST
+	plx
+	rts


### PR DESCRIPTION
not really a pull request, just showing the code and diff (also it doesn't work perfectly, snake isn't initially green, and the attrs change on different frames to the gb's screen updating as the SGB BIOS does not do them on the same frame)

basic ideas:
* tile $36 is reserved for changes we want SNES to detect
* the format of data in $8360 is:
  * byte 0: $5a when we are in-gameplay
  * subsequent bytes are control codes:
    * 0: we want to stop reading control codes
    * bit 7 clear value: number of snake X/Y bytes to set green
    * bit 7 set value: number of snake X/Y bytes to set red/brown
So on snake creation, it's `db $5a, $03, $07,$07, $07,$08, $07,$09, $00`.
When snake is not moving, it's `db $5a, $00`
When snake is moving, it's `db $5a, $01, <new snake X>,<new snake Y>, $81, <old tail X>, <old tail Y>, $00`

* SNES, on 1st read of the $5a, will set all the grid tile's attrs to red/brown
* It will handle the control codes as appropriate, setting grid tile's to green or red/brown